### PR TITLE
BUG: host_register and host_active should not be an array

### DIFF
--- a/www/modules/Discovery/include/results.php
+++ b/www/modules/Discovery/include/results.php
@@ -148,8 +148,8 @@ if (!empty($_POST)){
 					// Ajout macros
 				}
 				$tmpConf["host"]["host_snmp_version"] =  $hostInfos["snmp_version"];
-				$tmpConf["host"]["host_register"]["host_register"] = "1";
-				$tmpConf["host"]["host_activate"]["host_activate"] = "1";
+				$tmpConf["host"]["host_register"] = "1";
+				$tmpConf["host"]["host_activate"] = "1";
 				$tmpConf["host"]["host_template_model_htm_id"] = $_POST["select_template".$host];
 				if ($_POST["select_group".$host]!= -1)
 				{

--- a/www/modules/Discovery/sql/install.sql
+++ b/www/modules/Discovery/sql/install.sql
@@ -30,11 +30,11 @@
 --	
 -- Insertion des pages du module Centreon Discovery
 INSERT INTO `topology` (`topology_id`, `topology_name`, `topology_icone`, `topology_parent`, `topology_page`, `topology_order`, `topology_group`, `topology_url`, `topology_url_opt`, `topology_popup`, `topology_modules`, `topology_show`) 
-VALUES ('', 'Centreon Discovery', NULL, 6, 612, 100, 1, './modules/Discovery/include/ips.php', NULL, '0', '1', '1') ,
-('', 'IP addresses', './img/icones/16x16/client_network.gif', 612, 61201, 1, 1, './modules/Discovery/include/ips.php', NULL, '0', '1', '1') ,
-('', 'Results', './img/icones/16x16/column.gif', 612, 61202, 101, 1, './modules/Discovery/include/results.php', NULL, '0', '1', '1') ,
-('', 'Configuration', './img/icones/16x16/gear.gif', 612, 61203, 102, 1, './modules/Discovery/include/configuration.php', NULL, '0', '1', '1') , 
-('', 'About', './img/icones/16x16/about.gif', 612, 61204, 103, 1, './modules/Discovery/include/informations.php', NULL, '0', '1', '1');
+VALUES (NULL, 'Centreon Discovery', NULL, 6, 612, 100, 1, './modules/Discovery/include/ips.php', NULL, '0', '1', '1') ,
+(NULL, 'IP addresses', 612, 61201, 1, 1, './modules/Discovery/include/ips.php', NULL, '0', '1', '1') ,
+(NULL, 'Results', 612, 61202, 101, 1, './modules/Discovery/include/results.php', NULL, '0', '1', '1') ,
+(NUL, 'Configuration', 612, 61203, 102, 1, './modules/Discovery/include/configuration.php', NULL, '0', '1', '1') , 
+(NULL, 'About', 612, 61204, 103, 1, './modules/Discovery/include/informations.php', NULL, '0', '1', '1');
 
 
 -- DATABASE : @DB_NAME_CENTREON@


### PR DESCRIPTION
This bug prevents adding hosts into centreon version 2.8.14